### PR TITLE
Fix escape sequence for evil-lisp-state

### DIFF
--- a/evil-escape.el
+++ b/evil-escape.el
@@ -203,7 +203,12 @@ with a key sequence."
                                     :delete-func isearch-delete-char))
   ;; lisp state if installed
   (eval-after-load 'evil-lisp-state
-    '(eval '(evil-escape-define-escape "lisp-state" evil-lisp-state-map evil-normal-state)))
+    '(progn
+       (setq evil-escape-lisp-state-shadowed-func
+             (lookup-key evil-lisp-state-map (evil-escape--first-key)))
+       (eval `(evil-escape-define-escape "lisp-state" evil-lisp-state-map
+                                         evil-normal-state
+                                         :shadowed-func ,evil-escape-lisp-state-shadowed-func))))
   ;; iedit state if installed
   (eval-after-load 'evil-iedit-state
     '(progn


### PR DESCRIPTION
The command originally bound to the first key of the
evil-escape-sequence needs to be set as the shadowed function.
This was not the case for evil-lisp-state.

(fix #578 on spacemacs repository)