### PR TITLE
When replaying macro, execute shadow func

### DIFF
--- a/evil-escape.el
+++ b/evil-escape.el
@@ -152,8 +152,12 @@ with a key sequence."
                                     ',insert-func
                                     ',delete-func)
              ;; not called by the user, i.e. called by a keyboard macro
-             (when (fboundp ',insert-func)
-               (funcall ',insert-func ,(evil-escape--first-key)))))))))
+             (cond
+              ((fboundp ',insert-func)
+               (funcall ',insert-func ,(evil-escape--first-key)))
+              ((fboundp ',shadowed-func)
+               (evil-escape--setup-emacs-state-passthrough)
+               (evil-escape--execute-shadowed-func ',shadowed-func)))))))))
 
 (defun evil-escape--define-keys ()
   "Set the key bindings to escape _everything!_"


### PR DESCRIPTION
Currently when replaying recorded keys, keys pressed in insert mode are
correctly inserted into the buffer.  However keys that are repeated when
not in insert mode are ignored.  This change no longer ignores replayed
keys that are not hit in insert mode.

Fixes issue where on macro replay, f" did not move forward to the next "
character, but movement was ignored.