### PR TITLE
Don't break deft-mode

### DIFF
--- a/evil-escape.el
+++ b/evil-escape.el
@@ -297,10 +297,12 @@ with a key sequence."
   (when (not buffer-read-only) (delete-char -1)))
 
 (defun evil-escape--insert-state-delete-func ()
-  "Take care of term-mode."
+  "Take care of term-mode and other weird modes."
   (interactive)
   (cond ((eq 'term-mode major-mode)
          (call-interactively 'term-send-backspace))
+        ((eq 'deft-mode major-mode)
+         (call-interactively 'deft-filter-increment))
         (t (evil-escape--default-delete-func))))
 
 (defun evil-escape--escape-with-q ()


### PR DESCRIPTION
Deft-mode uses a read-only buffer with a custom bound insertion function.
Before this one could not type the first character of the escape sequence in any note filter.

I'm going to PR a deft layer to Spacemacs soon, found this problem in the course of testing it.