### PR TITLE
Fix line highlight flicker on partial escape

### DIFF
--- a/evil-escape.el
+++ b/evil-escape.el
@@ -364,9 +364,13 @@ DELETE-FUNC when calling CALLBACK. "
   (let* ((modified (buffer-modified-p))
          (fkey (elt keys 0))
          (fkeystr (char-to-string fkey))
-         (skey (elt keys 1)))
+         (skey (elt keys 1))
+         (hl-line-mode-before hl-line-mode))
     (if insert-func (funcall insert-func fkey))
+    ;; temporarily force line-mode locally to prevent flicker from read-event
+    (when (or global-hl-line-mode hl-line-mode) (hl-line-mode 1))
     (let* ((evt (read-event nil nil evil-escape-delay)))
+      (unless hl-line-mode-before (hl-line-mode -1))
       (cond
        ((null evt)
         (unless insert-func


### PR DESCRIPTION
This fixes an issue where typing an `f` in insert mode causes the line highlight to flicker even if not followed by a `d`. (This fix is not specific to an `fd` escape sequence).

The issue looked like this:
```
I am typing in insert mode.
But the buffer line is flickering at the points labeled below.
^       ^ ^^           ^
```

The cause is something strange about `read-event`. If `read-event` is called and `hl-line-mode` is off, the current line will stop being highlighted *even* if `global-hl-line-mode` is on. Until the end of the `read-event` at which point it will highlight again. But if `hl-line-mode` is on then the line is highlighted throughout the `read-event` execution. This `read-event` weirdness isn't specific to evil-escape, I tried it out manually to get these results.

This PR gets around the problem by enabling `hl-line-mode` prior to calling `read-event` if need be, but always obeys and restores the user's preference.