### PR TITLE
Fix evil-repeat problem

### DIFF
--- a/evil-escape.el
+++ b/evil-escape.el
@@ -128,7 +128,7 @@ with a key sequence."
   :group 'evil
   :global t
   (if evil-escape-mode
-      (add-hook 'pre-command-hook 'evil-escape-pre-command-hook)
+      (add-hook 'pre-command-hook 'evil-escape-pre-command-hook t)
     (remove-hook 'pre-command-hook 'evil-escape-pre-command-hook)))
 
 (defun evil-escape ()
@@ -153,11 +153,13 @@ with a key sequence."
   (with-demoted-errors "evil-escape: Error %S"
       (when (evil-escape-p)
         (let ((modified (buffer-modified-p))
+              (repeat-info evil-repeat-info)
               (inserted (evil-escape--insert))
               (fkey (elt evil-escape-key-sequence 0))
               (skey (elt evil-escape-key-sequence 1))
               (evt (read-event nil nil evil-escape-delay)))
           (when inserted (evil-escape--delete))
+          (setq evil-repeat-info repeat-info)
           (set-buffer-modified-p modified)
           (cond
            ((and (integerp evt)


### PR DESCRIPTION
1. Make sure the pre-command-hook is at the end of the list (after the
evil-repeat one)

2. Make sure evil-repeat-info (the saved keystrokes) is correct before
escaping.

Fixes #40