### PR TITLE
Make sure evil is enabled in current buffer

### DIFF
--- a/evil-escape.el
+++ b/evil-escape.el
@@ -191,7 +191,8 @@ with a key sequence."
 
 (defun evil-escape-p ()
   "Return non-nil if evil-escape can run."
-  (and (not evil-escape-inhibit)
+  (and evil-local-mode
+       (not evil-escape-inhibit)
        (or (window-minibuffer-p)
            (bound-and-true-p isearch-mode)
            (eq 'ibuffer-mode major-mode)


### PR DESCRIPTION
There's no reason to escape if evil-mode is disabled in the current buffer