### PR TITLE
custom handling for deft causes duplicate inserts

### DIFF
--- a/evil-escape.el
+++ b/evil-escape.el
@@ -292,7 +292,6 @@ with a key sequence."
   "Delete character while taking into account mode specifities."
   (pcase major-mode
     (`term-mode (call-interactively 'term-send-backspace))
-    (`deft-mode (call-interactively 'deft-filter-increment))
     (_ (cond
         ((bound-and-true-p isearch-mode) (isearch-delete-char))
         (t (evil-escape--delete-func))))))


### PR DESCRIPTION
as mentioned in syl20bnr/spacemacs#2366, the workaround for deft-mode causes the first char of the escape sequence to be inserted twice (e.g. pressing <kbd>f</kbd> causes `ff` to appear in the deft filter). Removing the line fixes this behaviour and <kbd>DEL</kbd> still works as expected.