### PR TITLE
Fix flickering when using 'global-hl-line-mode'

### DIFF
--- a/evil-escape.el
+++ b/evil-escape.el
@@ -144,7 +144,7 @@ with a key sequence."
   :group 'evil
   :global t
   (if evil-escape-mode
-      (add-hook 'pre-command-hook 'evil-escape-pre-command-hook t)
+      (add-hook 'pre-command-hook 'evil-escape-pre-command-hook)
     (remove-hook 'pre-command-hook 'evil-escape-pre-command-hook)))
 
 (defun evil-escape ()


### PR DESCRIPTION
This fix remove the display flickering when using global-hl-line-mode and evil-escape-mode (see #65).

`evil-escape-pre-command-hook` is now added at the beginning of `pre-command-hook` and so, called before `global-hl-line-unhighlight`.

This change in `pre-command-hook` order does not seem to be harmful elsewhere (evil-escape still works fine for me).