### PR TITLE
set this-original-command as well as this-command

### DIFF
--- a/evil-escape.el
+++ b/evil-escape.el
@@ -187,7 +187,10 @@ with a key sequence."
                           (equal (this-command-keys) (evil-escape--second-key))
                           (char-equal evt fkey))))
             (evil-repeat-stop)
-            (when (evil-escape-func) (setq this-command (evil-escape-func))))
+            (let ((esc-fun (evil-escape-func)))
+              (when esc-fun
+                (setq this-command esc-fun)
+                (setq this-original-command esc-fun))))
            ((null evt))
            (t (setq unread-command-events
                     (append unread-command-events (list evt)))))))))


### PR DESCRIPTION
Hi,

I am working on a PR for multiple-cursors, trying to get evil commands working.

I am working on getting evil escape functioning properly in it.

That library looks at [this-original-command](https://github.com/magnars/multiple-cursors.el/blob/master/multiple-cursors-core.el#L360).

I wrote some advice around `evil-escape-pre-command-hook` that looks at the value of `this-command` and if it is different after that hook, sets `this-original-command` to what `evil-escape` sets `this-command` to.

I thought that it might be ok to also set `this-original-command` in this library as there is no remapping going on, and per the docs they should be the same unless remapping has occurred.

What do you think?
