### PR TITLE
Use string-match-p over string-match

### DIFF
--- a/evil-escape.el
+++ b/evil-escape.el
@@ -330,7 +330,7 @@ with a key sequence."
 
 (defun evil-escape--is-magit-buffer ()
   "Return non nil if the current buffer is a Magit buffer."
-  (string-match "magit" (symbol-name major-mode)))
+  (string-match-p "magit" (symbol-name major-mode)))
 
 (provide 'evil-escape)
 


### PR DESCRIPTION
Since we don't need the match data