### PR TITLE
Exit multiedit-insert state into multiedit-state

### DIFF
--- a/evil-escape.el
+++ b/evil-escape.el
@@ -168,7 +168,7 @@ with a key sequence."
     (`iedit 'evil-iedit-state/quit-iedit-mode)
     (`iedit-insert 'evil-iedit-state/quit-iedit-mode)
     (`multiedit 'evil-multiedit-abort)
-    (`multiedit-insert 'evil-multiedit-abort)
+    (`multiedit-insert 'evil-multiedit-state)
     (_ (evil-escape--escape-normal-state))))
 
 (defun evil-escape-pre-command-hook ()


### PR DESCRIPTION
It makes more sense to leave `multiedit-insert-state` into `multiedit-state`, than to abort the entire multiedit session altogether.