### PR TITLE
remove leading space in package header

### DIFF
--- a/evil-escape.el
+++ b/evil-escape.el
@@ -1,4 +1,4 @@
- ;;; evil-escape.el --- Escape from anything with a customizable key sequence
+;;; evil-escape.el --- Escape from anything with a customizable key sequence
 
 ;; Copyright (C) 2014-2015 syl20bnr
 ;;


### PR DESCRIPTION
the space here causes a breakage, at least when trying to install through Nix. It throws "Package lacks a header". This fixed it for me, so I thought I'd send it upstream as well. 😄

Fix commit temporarily, in case anyone else using nixpkgs-unstable runs into this: https://github.com/BrianHicks/dotfiles.nix/commit/a98c55c6e9daa09c64ad037256cafab8a7ff2974