### PR TITLE
Add support for libvterm

### DIFF
--- a/evil-escape.el
+++ b/evil-escape.el
@@ -179,33 +179,33 @@ with a key sequence."
 (defun evil-escape-pre-command-hook ()
   "evil-escape pre-command hook."
   (with-demoted-errors "evil-escape: Error %S"
-      (when (evil-escape-p)
-        (let* ((modified (buffer-modified-p))
-               (inserted (evil-escape--insert))
-               (fkey (elt evil-escape-key-sequence 0))
-               (skey (elt evil-escape-key-sequence 1))
-               (evt (read-event nil nil evil-escape-delay)))
-          (when (and inserted (not (eq 'vterm-mode major-mode)))
-            (evil-escape--delete))
-          (set-buffer-modified-p modified)
-          (cond
-           ((and (characterp evt)
-                 (or (and (equal (this-command-keys) (evil-escape--first-key))
-                          (char-equal evt skey))
-                     (and evil-escape-unordered-key-sequence
-                          (equal (this-command-keys) (evil-escape--second-key))
-                          (char-equal evt fkey))))
-            (evil-repeat-stop)
-            (when (eq 'vterm-mode major-mode)
-              (vterm-send-key "<backspace>"))
-            (let ((esc-fun (evil-escape-func)))
-              (when esc-fun
-                (setq this-command esc-fun)
-                (setq this-original-command esc-fun))))
-           ((null evt))
-           ((not (eq 'vterm-mode major-mode))
-            (setq unread-command-events
-                  (append unread-command-events (list evt)))))))))
+    (when (evil-escape-p)
+      (let* ((modified (buffer-modified-p))
+             (inserted (evil-escape--insert))
+             (fkey (elt evil-escape-key-sequence 0))
+             (skey (elt evil-escape-key-sequence 1))
+             (evt (read-event nil nil evil-escape-delay)))
+        (when (and inserted (not (eq 'vterm-mode major-mode)))
+          (evil-escape--delete))
+        (set-buffer-modified-p modified)
+        (cond
+         ((and (characterp evt)
+               (or (and (equal (this-command-keys) (evil-escape--first-key))
+                        (char-equal evt skey))
+                   (and evil-escape-unordered-key-sequence
+                        (equal (this-command-keys) (evil-escape--second-key))
+                        (char-equal evt fkey))))
+          (evil-repeat-stop)
+          (when (eq 'vterm-mode major-mode)
+            (vterm-send-key "<backspace>"))
+          (let ((esc-fun (evil-escape-func)))
+            (when esc-fun
+              (setq this-command esc-fun)
+              (setq this-original-command esc-fun))))
+         ((null evt))
+         ((not (eq 'vterm-mode major-mode))
+          (setq unread-command-events
+                (append unread-command-events (list evt)))))))))
 
 (defadvice evil-repeat (around evil-escape-repeat-info activate)
   (let ((evil-escape-inhibit t))
@@ -301,8 +301,7 @@ with a key sequence."
         (`insert (evil-escape--insert-2) t)
         (`emacs (evil-escape--insert-2) t)
         (`hybrid (evil-escape--insert-2) t)
-        (`normal
-         (when (window-minibuffer-p) (evil-escape--insert-func) t))
+        (`normal (when (window-minibuffer-p) (evil-escape--insert-func) t))
         (`iedit-insert (evil-escape--insert-func) t))
     ('error nil)))
 
@@ -321,8 +320,7 @@ with a key sequence."
     (`insert (evil-escape--delete-2))
     (`emacs (evil-escape--delete-2))
     (`hybrid (evil-escape--delete-2))
-    (`normal
-     (when (minibuffer-window-active-p (evil-escape--delete-func))))
+    (`normal (when (minibuffer-window-active-p (evil-escape--delete-func))))
     (`iedit-insert (evil-escape--delete-func))))
 
 (defun evil-escape--delete-2 ()


### PR DESCRIPTION
I'm aware it might mot be the best fix in the univers but like this it _does work_. I just still don't understand exactly why I had to do it this way.

When I tried to just do it the exact same way as how it was done for `term`, ie. just adding the `vterm-mode` case in `evil-escape--insert-2` and `evil-escape--delete-2`, resulted in a strange behaviour that I still can't wrap my head around:

I use the unordered sequence `jk`. When I typed `jk` it would just work, exit insert state to normal state and none of the `j` or `k` remain inserted. Everything works fine.
But when I typed `make`, it would result in inserting `maee`. The `k` got deleted and `e` got inserted twice, hence the conditions that I put in `evil-escape-pre-command-hook`: only delete when actually escaping and do not reinsert `evt` in the `unread-command-events`.

If you merged it as-is it would just work, but I am very open to comments and improvements if you have a better understanding than me.

**NB:** As-is, the ``(`vterm-mode (vterm-send-key "<backspace>"))`` in `evil-escape--delete-2` will never get executed. I put it there to imitate the fix to `term`.