### PR TITLE
Don't redisplay and font locking while doing `evil-escape`

### DIFF
--- a/evil-escape.el
+++ b/evil-escape.el
@@ -180,13 +180,16 @@ with a key sequence."
   "evil-escape pre-command hook."
   (with-demoted-errors "evil-escape: Error %S"
       (when (evil-escape-p)
-        (let* ((modified (buffer-modified-p))
+        ;; don't inhibit redisplay, else visual mode j key will not be updated
+        (let* ((inhibit-redisplay nil)
+               (fontification-functions nil)
+               (modified (buffer-modified-p))
                (inserted (evil-escape--insert))
                (fkey (elt evil-escape-key-sequence 0))
                (skey (elt evil-escape-key-sequence 1))
                (evt (read-event nil nil evil-escape-delay)))
           (when inserted (evil-escape--delete))
-          (set-buffer-modified-p modified)
+          (restore-buffer-modified-p modified)
           (cond
            ((and (characterp evt)
                  (or (and (equal (this-command-keys) (evil-escape--first-key))


### PR DESCRIPTION
This should help resolve #84.
Also doing redisplay and font locking (due to `read-event`) in `evil-escape` is annoying since redisplay can slow down Emacs, and makes it easily to miss second key pressed.