### PR TITLE
Fix interference between evil-escape and kbd macro recording

### DIFF
--- a/evil-escape.el
+++ b/evil-escape.el
@@ -200,8 +200,8 @@ with a key sequence."
                 (setq this-command esc-fun)
                 (setq this-original-command esc-fun))))
            ((null evt))
-           (t (setq unread-command-events
-                    (append unread-command-events (list evt)))))))))
+           (t (setq unread-post-input-method-events
+                    (append unread-post-input-method-events (list evt)))))))))
 
 (defadvice evil-repeat (around evil-escape-repeat-info activate)
   (let ((evil-escape-inhibit t))


### PR DESCRIPTION
On Emacs 26.3, with evil-escape 3.14, and an ordered evil-escape key sequence "hg",
recording a keyboard macro:
"This is heavy"
Will be recorded as the keyboard macro:
"Thiis is heeavy"

Reinserting non-matching events into 'unread-post-input-method-events' instead of 'unread-command-events' fixes this, and does not appear to break normal use.