### PR TITLE
Give defcustoms correct customization types

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
         - [Key sequence](#key-sequence)
         - [Delay between keys](#delay-between-keys)
         - [Unordered key sequence](#unordered-key-sequence)
+        - [Case-insensitive key sequence](#case-insensitive-key-sequence)
         - [Excluding a major mode](#excluding-a-major-mode)
         - [Enable only for a list of major modes](#enable-only-for-a-list-of-major-modes)
         - [Inhibit evil-escape](#inhibit-evil-escape)
@@ -96,6 +97,13 @@ composed with the two same characters it is recommended to set the delay to
 
 The key sequence can be entered in any order by setting
 the variable `evil-escape-unordered-key-sequence` to non nil.
+
+### Case-Insensitive key sequence
+
+The key sequence can be entered without regard to case by setting
+the variable `evil-escape-case-insensitive-key-sequence` to non nil.
+
+This allows you to use df, DF, Df or dF to escape.
 
 ### Excluding a major mode
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Press quickly `fd` (or the 2-keys sequence of your choice) to:
 - quit gist-list menu
 - quit helm-ag-edit
 - hide neotree buffer
+- hide treemacs buffer
 - quit evil-multiedit
 
 And more to come !

--- a/evil-escape.el
+++ b/evil-escape.el
@@ -8,7 +8,7 @@
 ;; Keywords: convenience editing evil
 ;; Created: 22 Oct 2014
 ;; Version: 3.17
-;; Package-Requires: ((emacs "28") (evil "1.15.0") (cl-lib "0.5"))
+;; Package-Requires: ((emacs "27") (evil "1.15.0") (cl-lib "0.5"))
 ;; URL: https://github.com/smile13241324/evil-escape
 
 ;; This file is not part of GNU Emacs.

--- a/evil-escape.el
+++ b/evil-escape.el
@@ -200,8 +200,8 @@ with a key sequence."
                 (setq this-command esc-fun)
                 (setq this-original-command esc-fun))))
            ((null evt))
-           (t (setq unread-command-events
-                    (append unread-command-events (list evt)))))))))
+           (t (setq unread-post-input-method-events
+                    (append unread-post-input-method-events (list evt)))))))))
 
 (defadvice evil-repeat (around evil-escape-repeat-info activate)
   (let ((evil-escape-inhibit t))

--- a/evil-escape.el
+++ b/evil-escape.el
@@ -128,25 +128,25 @@ This allows you to use any of df, DF, Df or dF to escape."
   :type 'boolean
   :group 'evil-escape)
 
-(defcustom evil-escape-excluded-major-modes
-  nil "Excluded major modes where escape sequences have no effect."
-  :type 'sexp
+(defcustom evil-escape-excluded-major-modes nil
+  "Excluded major modes where escape sequences have no effect."
+  :type '(repeat symbol)
   :group 'evil-escape)
 
 (defcustom evil-escape-excluded-states nil
   "Excluded states where escape sequences have no effect."
-  :type 'sexp
+  :type '(repeat symbol)
   :group 'evil-escape)
 
-(defcustom evil-escape-enable-only-for-major-modes
-  nil "List of major modes where evil-escape is enabled."
-  :type 'sexp
+(defcustom evil-escape-enable-only-for-major-modes nil
+  "List of major modes where evil-escape is enabled."
+  :type '(repeat symbol)
   :group 'evil-escape)
 
 (defcustom evil-escape-inhibit-functions nil
   "List of zero argument predicate functions disabling evil-escape.
  If any of these functions return non nil, evil escape will be inhibited."
-  :type 'sexp
+  :type '(repeat function)
   :group 'evil-escape)
 
 (defvar evil-escape-inhibit nil "When non nil evil-escape is inhibited.")

--- a/evil-escape.el
+++ b/evil-escape.el
@@ -47,6 +47,7 @@
 ;;   - quit gist-list menu
 ;;   - quit helm-ag-edit
 ;;   - hide neotree buffer
+;;   - hide treemacs buffer
 ;;   - quit evil-multiedit
 ;; And more to come !
 
@@ -255,6 +256,7 @@ with a key sequence."
    ((and (fboundp 'helm-ag--edit-abort)
          (string-equal "*helm-ag-edit*" (buffer-name))) 'helm-ag--edit-abort)
    ((eq 'neotree-mode major-mode) 'neotree-hide)
+   ((eq 'treemacs-mode major-mode) 'treemacs-quit)
    (t 'evil-normal-state)))
 
 (defun evil-escape--escape-emacs-state ()

--- a/evil-escape.el
+++ b/evil-escape.el
@@ -155,6 +155,9 @@ This allows you to use any of df, DF, Df or dF to escape."
 (defvar evil-escape-inhibit nil
   "When non nil evil-escape is inhibited.")
 
+(defconst evil-escape-version "3.17"
+  "The current version of evil-escape")
+
 ;;;###autoload
 (define-minor-mode evil-escape-mode
   "Buffer-local minor mode to escape insert state and everything else

--- a/evil-escape.el
+++ b/evil-escape.el
@@ -7,7 +7,7 @@
 ;; Created: 22 Oct 2014
 ;; Version: 3.17
 ;; Package-Requires: ((emacs "24") (evil "1.0.9") (cl-lib "0.5"))
-;; URL: https://github.com/syl20bnr/evil-escape
+;; URL: https://github.com/smile13241324/evil-escape
 
 ;; This file is not part of GNU Emacs.
 
@@ -185,6 +185,7 @@ with a key sequence."
     (`iedit-insert 'evil-iedit-state/quit-iedit-mode)
     (`multiedit 'evil-multiedit-abort)
     (`multiedit-insert 'evil-multiedit-state)
+    (`treemacs 'treemacs-quit)
     (_ (evil-escape--escape-normal-state))))
 
 (defun evil-escape-command-keys ()
@@ -274,7 +275,6 @@ with a key sequence."
    ((and (fboundp 'helm-ag--edit-abort)
          (string-equal "*helm-ag-edit*" (buffer-name))) 'helm-ag--edit-abort)
    ((eq 'neotree-mode major-mode) 'neotree-hide)
-   ((eq 'treemacs-mode major-mode) 'treemacs-quit)
    (t 'evil-normal-state)))
 
 (defun evil-escape--escape-emacs-state ()

--- a/evil-escape.el
+++ b/evil-escape.el
@@ -124,7 +124,8 @@ key first."
   :group 'evil-escape)
 
 (defcustom evil-escape-case-insensitive-key-sequence nil
-  "if non-nil then the key sequence is case-insensitive. This allows you to use any of df, DF, Df or dF to escape."
+  "if non-nil then the key sequence is case-insensitive.
+This allows you to use any of df, DF, Df or dF to escape."
   :type 'boolean
   :group 'evil-escape)
 

--- a/evil-escape.el
+++ b/evil-escape.el
@@ -5,7 +5,7 @@
 ;; Author: Sylvain Benner <sylvain.benner@gmail.com>
 ;; Keywords: convenience editing evil
 ;; Created: 22 Oct 2014
-;; Version: 3.16
+;; Version: 3.17
 ;; Package-Requires: ((emacs "24") (evil "1.0.9") (cl-lib "0.5"))
 ;; URL: https://github.com/syl20bnr/evil-escape
 

--- a/evil-escape.el
+++ b/evil-escape.el
@@ -180,13 +180,16 @@ with a key sequence."
   "evil-escape pre-command hook."
   (with-demoted-errors "evil-escape: Error %S"
       (when (evil-escape-p)
-        (let* ((modified (buffer-modified-p))
+        ;; don't inhibit redisplay, else visual mode j key will not be updated
+        (let* ((inhibit-redisplay nil)
+               (fontification-functions nil)
+               (modified (buffer-modified-p))
                (inserted (evil-escape--insert))
                (fkey (elt evil-escape-key-sequence 0))
                (skey (elt evil-escape-key-sequence 1))
                (evt (read-event nil nil evil-escape-delay)))
           (when inserted (evil-escape--delete))
-          (set-buffer-modified-p modified)
+          (restore-buffer-modified-p modified)
           (cond
            ((and (characterp evt)
                  (or (and (equal (this-command-keys) (evil-escape--first-key))

--- a/evil-escape.el
+++ b/evil-escape.el
@@ -1,12 +1,14 @@
-;;; evil-escape.el --- Escape from anything with a customizable key sequence
+;;; evil-escape.el --- Escape from anything with a customizable key sequence -*- lexical-binding: t -*-
 
-;; Copyright (C) 2014-2015 syl20bnr
+;; Copyright (C) 2014-2015 syl20bnr and
+;; Copyright (C) 2022 smile13241324
 ;;
 ;; Author: Sylvain Benner <sylvain.benner@gmail.com>
+;;         Maxi Wolff <smile13241324@gmail.com>
 ;; Keywords: convenience editing evil
 ;; Created: 22 Oct 2014
 ;; Version: 3.17
-;; Package-Requires: ((emacs "24") (evil "1.0.9") (cl-lib "0.5"))
+;; Package-Requires: ((emacs "28") (evil "1.15.0") (cl-lib "0.5"))
 ;; URL: https://github.com/smile13241324/evil-escape
 
 ;; This file is not part of GNU Emacs.

--- a/evil-escape.el
+++ b/evil-escape.el
@@ -1,4 +1,4 @@
- ;;; evil-escape.el --- Escape from anything with a customizable key sequence
+;;; evil-escape.el --- Escape from anything with a customizable key sequence
 
 ;; Copyright (C) 2014-2015 syl20bnr
 ;;

--- a/evil-escape.el
+++ b/evil-escape.el
@@ -96,11 +96,10 @@
 (require 'evil)
 (require 'cl-lib)
 
-(eval-when-compile
-  (declare-function evil-iedit-state/quit-iedit-mode "evil-iedit-state.el"))
+(eval-when-compile (declare-function evil-iedit-state/quit-iedit-mode
+                                                         "evil-iedit-state.el"))
 
-(defgroup evil-escape nil
-  "Key sequence to escape insert state and everything else."
+(defgroup evil-escape nil "Key sequence to escape insert state and everything else."
   :prefix "evil-escape-"
   :group 'evil)
 
@@ -114,25 +113,23 @@
   :type 'sexp
   :group 'evil-escape)
 
-(defcustom evil-escape-delay 0.1
-  "Max time delay between two key presses."
+(defcustom evil-escape-delay 0.1 "Max time delay between two key presses."
   :type 'number
   :group 'evil-escape)
 
-(defcustom evil-escape-unordered-key-sequence nil
-  "If non-nil then the key sequence can also be entered with the second
-key first."
-  :type 'boolean
+(defcustom evil-escape-unordered-key-sequence
+  nil "If non-nil then the key sequence can also be entered with the second
+key first." :type 'boolean
   :group 'evil-escape)
 
-(defcustom evil-escape-case-insensitive-key-sequence nil
-  "if non-nil then the key sequence is case-insensitive.
+(defcustom evil-escape-case-insensitive-key-sequence
+  nil "if non-nil then the key sequence is case-insensitive.
 This allows you to use any of df, DF, Df or dF to escape."
   :type 'boolean
   :group 'evil-escape)
 
-(defcustom evil-escape-excluded-major-modes nil
-  "Excluded major modes where escape sequences have no effect."
+(defcustom evil-escape-excluded-major-modes
+  nil "Excluded major modes where escape sequences have no effect."
   :type 'sexp
   :group 'evil-escape)
 
@@ -141,8 +138,8 @@ This allows you to use any of df, DF, Df or dF to escape."
   :type 'sexp
   :group 'evil-escape)
 
-(defcustom evil-escape-enable-only-for-major-modes nil
-  "List of major modes where evil-escape is enabled."
+(defcustom evil-escape-enable-only-for-major-modes
+  nil "List of major modes where evil-escape is enabled."
   :type 'sexp
   :group 'evil-escape)
 
@@ -152,11 +149,9 @@ This allows you to use any of df, DF, Df or dF to escape."
   :type 'sexp
   :group 'evil-escape)
 
-(defvar evil-escape-inhibit nil
-  "When non nil evil-escape is inhibited.")
+(defvar evil-escape-inhibit nil "When non nil evil-escape is inhibited.")
 
-(defconst evil-escape-version "3.17"
-  "The current version of evil-escape")
+(defconst evil-escape-version "3.17" "The current version of evil-escape")
 
 ;;;###autoload
 (define-minor-mode evil-escape-mode
@@ -220,6 +215,13 @@ with a key sequence."
           (evil-repeat-stop)
           (let ((esc-fun (evil-escape-func)))
             (when esc-fun
+
+              ;; Escape from company when active
+              (when (and
+                     (fboundp 'company--active-p)
+                     (company--active-p))
+                (company-abort))
+
               (setq this-command esc-fun)
               (setq this-original-command esc-fun))))
          ((null evt))

--- a/evil-escape.el
+++ b/evil-escape.el
@@ -5,7 +5,7 @@
 ;; Author: Sylvain Benner <sylvain.benner@gmail.com>
 ;; Keywords: convenience editing evil
 ;; Created: 22 Oct 2014
-;; Version: 3.15
+;; Version: 3.16
 ;; Package-Requires: ((emacs "24") (evil "1.0.9") (cl-lib "0.5"))
 ;; URL: https://github.com/syl20bnr/evil-escape
 

--- a/evil-escape.el
+++ b/evil-escape.el
@@ -96,8 +96,8 @@
 (require 'evil)
 (require 'cl-lib)
 
-(eval-when-compile (declare-function evil-iedit-state/quit-iedit-mode
-                                                         "evil-iedit-state.el"))
+(eval-when-compile
+  (declare-function evil-iedit-state/quit-iedit-mode "evil-iedit-state.el"))
 
 (defgroup evil-escape nil "Key sequence to escape insert state and everything else."
   :prefix "evil-escape-"
@@ -117,13 +117,14 @@
   :type 'number
   :group 'evil-escape)
 
-(defcustom evil-escape-unordered-key-sequence
-  nil "If non-nil then the key sequence can also be entered with the second
-key first." :type 'boolean
+(defcustom evil-escape-unordered-key-sequence nil
+  "If non-nil then the key sequence can also be entered with the second key first."
+  :type 'boolean
   :group 'evil-escape)
 
-(defcustom evil-escape-case-insensitive-key-sequence
-  nil "if non-nil then the key sequence is case-insensitive.
+(defcustom evil-escape-case-insensitive-key-sequence nil
+  "If non-nil, the key sequence is case-insensitive.
+
 This allows you to use any of df, DF, Df or dF to escape."
   :type 'boolean
   :group 'evil-escape)
@@ -149,9 +150,11 @@ This allows you to use any of df, DF, Df or dF to escape."
   :type '(repeat function)
   :group 'evil-escape)
 
-(defvar evil-escape-inhibit nil "When non nil evil-escape is inhibited.")
+(defvar evil-escape-inhibit nil
+  "When non-nil, evil-escape is inhibited.")
 
-(defconst evil-escape-version "3.17" "The current version of evil-escape")
+(defconst evil-escape-version "3.17"
+  "The current version of evil-escape")
 
 ;;;###autoload
 (define-minor-mode evil-escape-mode
@@ -189,7 +192,10 @@ with a key sequence."
     (_ (evil-escape--escape-normal-state))))
 
 (defun evil-escape-command-keys ()
-  (if (and evil-escape-case-insensitive-key-sequence (char-or-string-p (this-command-keys))) (downcase (this-command-keys)) (this-command-keys)))
+  (if (and evil-escape-case-insensitive-key-sequence
+           (char-or-string-p (this-command-keys)))
+      (downcase (this-command-keys))
+    (this-command-keys)))
 
 (defun evil-escape-pre-command-hook ()
   "evil-escape pre-command hook."
@@ -312,11 +318,13 @@ with a key sequence."
 
 (defun evil-escape--insert-func ()
   "Default insert function."
-  (when (not buffer-read-only) (self-insert-command 1)))
+  (unless buffer-read-only
+    (self-insert-command 1)))
 
 (defun evil-escape--delete-func ()
   "Delete char in current buffer if not read only."
-  (when (not buffer-read-only) (delete-char -1)))
+  (unless buffer-read-only
+    (delete-char -1)))
 
 (defun evil-escape--insert ()
   "Insert the first key of the sequence."
@@ -331,7 +339,7 @@ with a key sequence."
     ('error nil)))
 
 (defun evil-escape--insert-2 ()
-  "Insert character while taking into account mode specificites."
+  "Insert character while taking into account mode specificities."
   (pcase major-mode
     (`term-mode (call-interactively 'term-send-raw))
     (_ (cond
@@ -349,7 +357,7 @@ with a key sequence."
     (`iedit-insert (evil-escape--delete-func))))
 
 (defun evil-escape--delete-2 ()
-  "Delete character while taking into account mode specifities."
+  "Delete character while taking into account mode specificities."
   (pcase major-mode
     (`term-mode (call-interactively 'term-send-backspace))
     (_ (cond

--- a/evil-escape.el
+++ b/evil-escape.el
@@ -187,37 +187,37 @@ with a key sequence."
     (_ (evil-escape--escape-normal-state))))
 
 (defun evil-escape-command-keys ()
-    (if (and evil-escape-case-insensitive-key-sequence (char-or-string-p (this-command-keys))) (downcase (this-command-keys)) (this-command-keys)))
+  (if (and evil-escape-case-insensitive-key-sequence (char-or-string-p (this-command-keys))) (downcase (this-command-keys)) (this-command-keys)))
 
 (defun evil-escape-pre-command-hook ()
   "evil-escape pre-command hook."
   (with-demoted-errors "evil-escape: Error %S"
-      (when (evil-escape-p)
-        ;; don't inhibit redisplay, else visual mode j key will not be updated
-        (let* ((inhibit-redisplay nil)
-               (fontification-functions nil)
-               (modified (buffer-modified-p))
-               (inserted (evil-escape--insert))
-               (fkey (elt evil-escape-key-sequence 0))
-               (skey (elt evil-escape-key-sequence 1))
-               (evt (read-event nil nil evil-escape-delay)))
-          (when inserted (evil-escape--delete))
-          (restore-buffer-modified-p modified)
-          (cond
-           ((and (characterp evt)
-                 (or (and (equal (evil-escape-command-keys) (evil-escape--first-key))
-                          (char-equal evt skey))
-                     (and evil-escape-unordered-key-sequence
-                          (equal (evil-escape-command-keys) (evil-escape--second-key))
-                          (char-equal evt fkey))))
-            (evil-repeat-stop)
-            (let ((esc-fun (evil-escape-func)))
-              (when esc-fun
-                (setq this-command esc-fun)
-                (setq this-original-command esc-fun))))
-           ((null evt))
-           (t (setq unread-post-input-method-events
-                    (append unread-post-input-method-events (list evt)))))))))
+    (when (evil-escape-p)
+      ;; don't inhibit redisplay, else visual mode j key will not be updated
+      (let* ((inhibit-redisplay nil)
+             (fontification-functions nil)
+             (modified (buffer-modified-p))
+             (inserted (evil-escape--insert))
+             (fkey (elt evil-escape-key-sequence 0))
+             (skey (elt evil-escape-key-sequence 1))
+             (evt (read-event nil nil evil-escape-delay)))
+        (when inserted (evil-escape--delete))
+        (restore-buffer-modified-p modified)
+        (cond
+         ((and (characterp evt)
+               (or (and (equal (evil-escape-command-keys) (evil-escape--first-key))
+                        (char-equal evt skey))
+                   (and evil-escape-unordered-key-sequence
+                        (equal (evil-escape-command-keys) (evil-escape--second-key))
+                        (char-equal evt fkey))))
+          (evil-repeat-stop)
+          (let ((esc-fun (evil-escape-func)))
+            (when esc-fun
+              (setq this-command esc-fun)
+              (setq this-original-command esc-fun))))
+         ((null evt))
+         (t (setq unread-post-input-method-events
+                  (append unread-post-input-method-events (list evt)))))))))
 
 (defadvice evil-repeat (around evil-escape-repeat-info activate)
   (let ((evil-escape-inhibit t))

--- a/evil-escape.el
+++ b/evil-escape.el
@@ -234,9 +234,9 @@ with a key sequence."
          (t (setq unread-post-input-method-events
                   (append unread-post-input-method-events (list evt)))))))))
 
-(defadvice evil-repeat (around evil-escape-repeat-info activate)
+(define-advice evil-repeat (:around (f &rest args) evil-escape-repeat-info)
   (let ((evil-escape-inhibit t))
-    ad-do-it))
+    (apply f args)))
 
 (defun evil-escape-p ()
   "Return non-nil if evil-escape can run."

--- a/evil-escape.el
+++ b/evil-escape.el
@@ -36,6 +36,7 @@
 ;;   - quit minibuffer
 ;;   - quit compilation buffers
 ;;   - abort isearch
+;;   - abort ctrlf
 ;;   - quit ibuffer
 ;;   - quit image buffer
 ;;   - quit magit buffers
@@ -213,6 +214,7 @@ with a key sequence."
        (not evil-escape-inhibit)
        (or (window-minibuffer-p)
            (bound-and-true-p isearch-mode)
+           (bound-and-true-p ctrlf--active-p)
            (memq major-mode '(ibuffer-mode
                               image-mode))
            (evil-escape--is-magit-buffer)
@@ -239,6 +241,7 @@ with a key sequence."
    ((eq 'image-mode major-mode) 'quit-window)
    ((evil-escape--is-magit-buffer) 'evil-escape--escape-with-q)
    ((bound-and-true-p isearch-mode) 'isearch-abort)
+   ((bound-and-true-p ctrlf--active-p) 'ctrlf-cancel)
    ((window-minibuffer-p) 'abort-recursive-edit)
    (t (lookup-key evil-normal-state-map [escape]))))
 
@@ -261,6 +264,7 @@ with a key sequence."
   "Return the function to escape from emacs state."
   (cond
    ((bound-and-true-p isearch-mode) 'isearch-abort)
+   ((bound-and-true-p ctrlf--active-p) 'ctrlf-cancel)
    ((window-minibuffer-p) 'abort-recursive-edit)
    ((evil-escape--is-magit-buffer) 'evil-escape--escape-with-q)
    ((eq 'ibuffer-mode major-mode) 'ibuffer-quit)

--- a/evil-escape.el
+++ b/evil-escape.el
@@ -185,7 +185,7 @@ with a key sequence."
     (_ (evil-escape--escape-normal-state))))
 
 (defun evil-escape-command-keys ()
-    (if evil-escape-case-insensitive-key-sequence (downcase (this-command-keys)) (this-command-keys)))
+    (if (and evil-escape-case-insensitive-key-sequence (char-or-string-p (this-command-keys))) (downcase (this-command-keys)) (this-command-keys)))
 
 (defun evil-escape-pre-command-hook ()
   "evil-escape pre-command hook."

--- a/evil-escape.el
+++ b/evil-escape.el
@@ -62,6 +62,9 @@
 ;; The key sequence can be entered in any order by setting
 ;; the variable `evil-escape-unordered-key-sequence' to non nil.
 
+;; The key sequence can be made case-insensitive by setting
+;; the variable `evil-escape-case-insensitive-key-sequence' to non nil.
+
 ;; A major mode can be excluded by adding it to the list
 ;; `evil-escape-excluded-major-modes'.
 
@@ -115,6 +118,11 @@
 (defcustom evil-escape-unordered-key-sequence nil
   "If non-nil then the key sequence can also be entered with the second
 key first."
+  :type 'boolean
+  :group 'evil-escape)
+
+(defcustom evil-escape-case-insensitive-key-sequence nil
+  "if non-nil then the key sequence is case-insensitive. This allows you to use any of df, DF, Df or dF to escape."
   :type 'boolean
   :group 'evil-escape)
 
@@ -176,6 +184,9 @@ with a key sequence."
     (`multiedit-insert 'evil-multiedit-state)
     (_ (evil-escape--escape-normal-state))))
 
+(defun evil-escape-command-keys ()
+    (if evil-escape-case-insensitive-key-sequence (downcase (this-command-keys)) (this-command-keys)))
+
 (defun evil-escape-pre-command-hook ()
   "evil-escape pre-command hook."
   (with-demoted-errors "evil-escape: Error %S"
@@ -189,10 +200,10 @@ with a key sequence."
           (set-buffer-modified-p modified)
           (cond
            ((and (characterp evt)
-                 (or (and (equal (this-command-keys) (evil-escape--first-key))
+                 (or (and (equal (evil-escape-command-keys) (evil-escape--first-key))
                           (char-equal evt skey))
                      (and evil-escape-unordered-key-sequence
-                          (equal (this-command-keys) (evil-escape--second-key))
+                          (equal (evil-escape-command-keys) (evil-escape--second-key))
                           (char-equal evt fkey))))
             (evil-repeat-stop)
             (let ((esc-fun (evil-escape-func)))
@@ -224,9 +235,9 @@ with a key sequence."
        (not (memq evil-state evil-escape-excluded-states))
        (or (not evil-escape-enable-only-for-major-modes)
            (memq major-mode evil-escape-enable-only-for-major-modes))
-       (or (equal (this-command-keys) (evil-escape--first-key))
+       (or (equal (evil-escape-command-keys) (evil-escape--first-key))
            (and evil-escape-unordered-key-sequence
-                (equal (this-command-keys) (evil-escape--second-key))))
+                (equal (evil-escape-command-keys) (evil-escape--second-key))))
        (not (cl-reduce (lambda (x y) (or x y))
                        (mapcar 'funcall evil-escape-inhibit-functions)
                        :initial-value nil))))


### PR DESCRIPTION
`sexp` is more generic of a type than these defcustoms actually
accept.  This PR adds more precise types, and fixes up some other
issues while we're at it.